### PR TITLE
添加 gpg2 证书 https://rvm.io/pkuczynski.asc

### DIFF
--- a/src/base/rvm/Dockerfile
+++ b/src/base/rvm/Dockerfile
@@ -3,6 +3,7 @@ FROM openrasp/centos7
 MAINTAINER OpenRASP <ext_yunfenxi@baidu.com>
 
 RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - \
+	&& curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - \
 	&& curl -sSL https://get.rvm.io | bash -s stable
 
 COPY *.sh /root/


### PR DESCRIPTION
未添加的话会报如下错误

```
Step 1/6 : FROM openrasp/centos7
 ---> 319053c13357
Step 2/6 : MAINTAINER OpenRASP <ext_yunfenxi@baidu.com>
 ---> Using cache
 ---> c55df14c9871
Step 3/6 : RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - 	&& curl -sSL https://get.rvm.io | bash -s stable
 ---> Running in 9eff174772c3
gpg: directory `/root/.gnupg' created
gpg: new configuration file `/root/.gnupg/gpg.conf' created
gpg: WARNING: options in `/root/.gnupg/gpg.conf' are not yet active during this run
gpg: keyring `/root/.gnupg/secring.gpg' created
gpg: keyring `/root/.gnupg/pubring.gpg' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key D39DC0E3: public key "Michal Papis (RVM signing) <mpapis@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
gpg: no ultimately trusted keys found
Downloading https://github.com/rvm/rvm/archive/1.29.9.tar.gz
Downloading https://github.com/rvm/rvm/releases/download/1.29.9/1.29.9.tar.gz.asc
gpg: Signature made Wed Jul 10 16:31:02 2019 CST using RSA key ID 39499BDB
gpg: Can't check signature: No public key
GPG signature verification failed for '/usr/local/rvm/archives/rvm-1.29.9.tgz' - 'https://github.com/rvm/rvm/releases/download/1.29.9/1.29.9.tar.gz.asc'! Try to install GPG v2 and then fetch the public key:

    gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB

or if it fails:

    command curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
    command curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -

In case of further problems with validation please refer to https://rvm.io/rvm/security

The command '/bin/sh -c curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - 	&& curl -sSL https://get.rvm.io | bash -s stable' returned a non-zero code: 2
make[2]: *** [build] Error 2
make[1]: *** [build] Error 2
make: *** [base/ruby2.2.3/.] Error 2
```